### PR TITLE
server part for handling multipart file upload using "multiparty" package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ ModelManifest.xml
 node_modules
 build/
 *.sublime-workspace
+_upload/

--- a/Server/.jshintrc
+++ b/Server/.jshintrc
@@ -20,7 +20,7 @@
     "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
     "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
     "plusplus"      : false,    // true: Prohibit use of `++` & `--`
-    "quotmark"      : false,    // Quotation mark consistency:
+    "quotmark"      : "single", // Quotation mark consistency:
                                 //   false    : do nothing (default)
                                 //   true     : ensure whatever is used is consistent
                                 //   "single" : require single quotes

--- a/Server/package.json
+++ b/Server/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "body-parser": "^1.13.1",
-    "express": "^4.13.0"
+    "express": "^4.13.0",
+    "multiparty": "^4.1.2"
   }
 }

--- a/Server/server.js
+++ b/Server/server.js
@@ -1,6 +1,10 @@
+'use strict';
+
 import http from 'http';
 import express from 'express';
 import bodyParser from 'body-parser';
+import multiparty from 'multiparty';
+import fs from 'fs';
 
 let app = express();
 app.use(bodyParser.json());
@@ -8,13 +12,47 @@ app.use(bodyParser.json());
 let server = http.createServer(app);
 let portNumber = 4000;
 
-console.log("Listening on port " + portNumber);
+console.log('Listening on port ' + portNumber);
 server.listen(portNumber);
 
 app.get('/', (req, res) => {
-    res.send('ok');
+    res.writeHead(200, {'content-type': 'text/html'});
+    res.end(
+        '<form action="/upload" enctype="multipart/form-data" method="post">'+
+            '<input type="text" name="title"><br>'+
+            '<input type="file" name="upload" multiple="multiple"><br>'+
+            '<input type="submit" value="Upload">'+
+        '</form>'
+    );
 });
 
-app.post('/', (req, res) => {
-    res.end();
+app.post('/upload', (req, res) => {
+    let form = new multiparty.Form();
+
+    form.on('part', function(part) {
+        if (!_isAFile(part)) {
+            part.resume();
+        }
+
+        if (_isAFile(part)) {
+            console.log('got file named ' + part.filename);
+            part.pipe(fs.createWriteStream('../Server/_upload/' + part.filename));
+        }
+
+        part.on('error', function(err) {
+            console.log('error', err);
+        });
+    });
+
+    form.on('close', function() {
+      console.log('Upload completed!');
+      res.writeHead(200, {'content-type': 'text/plain'});
+      res.end('Received files');
+    });
+
+    form.parse(req);
 });
+
+function _isAFile(part) {
+    return part.filename;
+}


### PR DESCRIPTION
Thanks to this code, multipart data request can be send to the server.
You need to use 'http://localhost:4000/upload' address after starting the server.

to be improved:
- setting temp file path for saving
- code readability
- creating a data contract for request
- validation
